### PR TITLE
feature: adding server hostname

### DIFF
--- a/src/DataObjects/Server.php
+++ b/src/DataObjects/Server.php
@@ -14,6 +14,7 @@ final class Server
      * @param null|string $protocol The HTTP protocol used
      * @param null|OS $os The OS object
      * @param null|string $encoding
+     * @param null|string $hostname
      */
     public function __construct(
         public null|string $ip,
@@ -23,6 +24,7 @@ final class Server
         public null|string $protocol,
         public null|OS $os,
         public null|string $encoding,
+        public null|string $hostname,
     ) {
     }
 
@@ -38,7 +40,8 @@ final class Server
      *         release: null|string,
      *         architecture: null|string
      *     }|null,
-     *     encoding: null|string
+     *     encoding: null|string,
+     *     hostname: null|string
      * }
      */
     public function __toArray(): array
@@ -51,6 +54,7 @@ final class Server
             'protocol' => $this->protocol,
             'os' => $this->os?->__toArray(),
             'encoding' => $this->encoding,
+            'hostname' => $this->hostname,
         ];
     }
 }


### PR DESCRIPTION
This PR adds an additional optional parameter to the Server Data Object, allowing the SDK to pass through an optional hostname, for those situations where you want to detect specific servers behind a load balancer.